### PR TITLE
Update documentation links

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -13,8 +13,6 @@ DaxLib.SVG is a DAX User-Defined Functions (UDF) library designed to make creati
    
 For detailed examples, check out our [example PBIP file](https://github.com/daxlib/dev-daxlib-svg/tree/main/samples/pbip/svg).
 
----
-
 ## Function Categories
 
 | Category | Description |
@@ -28,4 +26,6 @@ For detailed examples, check out our [example PBIP file](https://github.com/daxl
 | **Scales** | Mapping values between scales |
 | **Colors** | Themes and functions for colour manipulation |
 
----
+## Documentation
+
+See the [documentation](https://evaluationcontext.github.io/daxlib.svg/) for more details.

--- a/src/manifest.daxlib
+++ b/src/manifest.daxlib
@@ -5,7 +5,7 @@
   "authors": "Kurt Buhler, Jake Duddy",
   "description": "A DAX User-Defined Functions (UDF) library designed to make creating SVG visuals in Power BI easier",
   "releaseNotes": "Added Documentation page and complete refactor of functions, presenting primatives as Elements and combination of primatives as Compounds",
-  "projectUrl": "https://github.com/daxlib/dev-daxlib-svg",
+  "projectUrl": "https://evaluationcontext.github.io/daxlib.svg",
   "repositoryUrl": "https://github.com/daxlib/dev-daxlib-svg",
   "tags": "DAX,UDF,FUNCTION,LIB,SVG",
   "icon": "/icon.png",


### PR DESCRIPTION
Update documentation links to use GitHub Pages until the definitive URL is available.

/cc @EvaluationContext 
