### PR TITLE
Update publish-package-pr.yml

### DIFF
--- a/.github/workflows/publish-package-pr.yml
+++ b/.github/workflows/publish-package-pr.yml
@@ -85,11 +85,13 @@ jobs:
             echo "action=Add" >> $GITHUB_OUTPUT
             git checkout -b "${BRANCH_NAME}"
           fi
-              
-      # Create the package folder if it doesn't exist
+
+      # Create the package folder (clean any previous content first)
       - name: Create package folder
         working-directory: upstream-repo
-        run: mkdir -p "${{ steps.package.outputs.folder }}"
+        run: |
+          rm -rf "${{ steps.package.outputs.folder }}"
+          mkdir -p "${{ steps.package.outputs.folder }}"
 
       # Copy package files to the new folder
       - name: Copy package files


### PR DESCRIPTION
Clean package folder before copying source files in yml workflow. On re-runs targeting an existing branch, stale files from the previous run may persist in the working tree. In particular, a previously merged lib/functions.tmdl would not be overwritten by the copy step when the source uses only the multi-file layout (lib/functions/**/*.tmdl), causing the Merge TMDL files step to append duplicate content on every re-run. Replacing mkdir -p with rm -rf + mkdir -p ensures the destination folder always reflects the source exactly, regardless of how many times the workflow is triggered for the same package version.